### PR TITLE
Improv patch 1 multithreading

### DIFF
--- a/idt/bing_api.py
+++ b/idt/bing_api.py
@@ -64,5 +64,5 @@ class BingApiSearchEngine:
 							break; 
 					except:
 						continue
-			self.downloaded_images -= erase_duplicates(target_folder)
+				self.downloaded_images -= erase_duplicates(target_folder)
 		generate_class_info(self.dataset_info,self.root_folder, self.folder)

--- a/idt/duckgo.py
+++ b/idt/duckgo.py
@@ -2,15 +2,14 @@ import requests;
 import re;
 import json;
 import time;
-import logging;
 import os;
 from rich.progress import Progress
+from concurrent.futures import ThreadPoolExecutor
 
-from idt.utils.download_images import download
+from idt.utils.download_thread_images import downloadThread
 from idt.utils.remove_corrupt import erase_duplicates
 
 __name__ = "duckgo"
-
 class DuckGoSearchEngine:
     def __init__(self,  data, n_images, folder, resize_method, root_folder, size):
         self.data = data
@@ -21,7 +20,7 @@ class DuckGoSearchEngine:
         self.size = size
         self.downloaded_images = 0
         self.search()
-
+    
     def search(self):
         URL = 'https://duckduckgo.com/'
         PARAMS = {'q': self.data}
@@ -38,7 +37,6 @@ class DuckGoSearchEngine:
 
         res = requests.post(URL, data=PARAMS, timeout=3.000)
         search_object = re.search(r'vqd=([\d-]+)\&', res.text, re.M|re.I)
-        #print(search_object)
 
         if not search_object:
             return -1;
@@ -54,14 +52,13 @@ class DuckGoSearchEngine:
 
         request_url = URL + "i.js";
         with Progress() as progress:
-
             task1 = progress.add_task("[blue]Downloading {x} class...".format(x=self.data), total=self.n_images)
             while self.downloaded_images < self.n_images:
                 while True:
                     try:
-                        res = requests.get(request_url, headers=HEADERS, params=PARAMS, timeout=3.000);
+                        res = requests.get(request_url, headers=HEADERS, params=PARAMS, timeout=3.000, stream=True);
                         data = json.loads(res.text);
-                        break;
+                        break
                     except ValueError as e:
                         time.sleep(5);
                         continue;
@@ -77,14 +74,10 @@ class DuckGoSearchEngine:
                 if len(data["results"]) > self.n_images - self.downloaded_images:
                     data["results"] = data["results"][:self.n_images - self.downloaded_images]
 
-                for results in data["results"]:
-                    try:
-                        download(results["image"], self.size, self.root_folder, self.folder, self.resize_method)
-                        self.downloaded_images+= 1
-                        progress.update(task1, advance=1) 
-                    except Exception as e:
-                        continue
-                        
+                with ThreadPoolExecutor(max_workers=5) as executor:
+                    {executor.submit(downloadThread, results["image"], self): results for results in data["results"]}
+                    progress.update(task1, advance=self.downloaded_images)
+                
                 self.downloaded_images -= erase_duplicates(target_folder)
 
                 if "next" not in data:

--- a/idt/flickr_api.py
+++ b/idt/flickr_api.py
@@ -71,4 +71,4 @@ class FlickrApiSearchEngine:
 							break; 
 					except:
 						continue
-			self.downloaded_images -= erase_duplicates(target_folder)
+				self.downloaded_images -= erase_duplicates(target_folder)

--- a/idt/utils/download_thread_images.py
+++ b/idt/utils/download_thread_images.py
@@ -1,0 +1,12 @@
+from idt.utils.download_images import download
+
+__name__ = "download_thread_images"
+def downloadThread(link, self):
+    try:
+        if(self.downloaded_images <= self.n_images):
+            download(link, self.size, self.root_folder, self.folder, self.resize_method)
+            self.downloaded_images += 1
+        else:
+            raise Exception("Exceed")
+    except Exception as e:
+        pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ requests==2.22.0
 Pillow==7.0.0
 rich==6.1.2
 numpy==1.19.1
-
+futures==3.3.0


### PR DESCRIPTION
This PR changes the download function for the Flickr and bing search class. Was added a new way to multithreading the data URL's for a fast download increasing a way better performance with big image searches.

To test the improvement, first Initializing the IDT and create all needed parameters, and after that build the dataset requested, the time will be faster than usual, by the multithreading all download subprocess will work to download the images.

In local tests, this was the result of some ways to download a sample of just one class and a sample of 100 images sample per search in the changed classes. The "normal" represents the time without the multithreading, and others with the tests max_workers of threads run simultaneously like 5 and 10. 

- duckgo - 
5 threads - 1:36
10 threads - 1:48
Normal - 04:05

- bing -
5 threads - 1:06
10 threads - 0:49
Normal - 03:52 

before start the build
![image](https://user-images.githubusercontent.com/41343708/104110153-7924a380-52b3-11eb-8a3a-9239eef8139d.png)

after start the build
![image](https://user-images.githubusercontent.com/41343708/104110172-b1c47d00-52b3-11eb-9a81-66690c460938.png)

the use of multithreading on a pc with 8gb RAM like mine, don't have negative effects, the tools work great!

